### PR TITLE
Support For Django 1.9

### DIFF
--- a/dirty_bits.py
+++ b/dirty_bits.py
@@ -1,4 +1,8 @@
-from django.apps import apps
+try:  # Django 1.9+
+    from django.apps import apps
+    get_models = apps.get_models
+except ImportError:  # Django < 1.9
+    from django.db.models import get_models
 from django.db.models import ManyToManyField
 from django.db.models.signals import post_init, post_save
 from threading import Lock
@@ -12,7 +16,7 @@ NEW_MODEL_HASH = None
 
 
 def register_all(strict=False):
-    models = apps.get_models()
+    models = get_models()
     for model in models:
         register(model, strict)
 

--- a/dirty_bits.py
+++ b/dirty_bits.py
@@ -1,4 +1,5 @@
-from django.db.models import get_models, ManyToManyField
+from django.apps import apps
+from django.db.models import ManyToManyField
 from django.db.models.signals import post_init, post_save
 from threading import Lock
 
@@ -11,7 +12,7 @@ NEW_MODEL_HASH = None
 
 
 def register_all(strict=False):
-    models = get_models()
+    models = apps.get_models()
     for model in models:
         register(model, strict)
 


### PR DESCRIPTION
This pull request changes the import of `get_models()`, based on changes in Django1.9. Now, the import works for Django1.9+, as well as Django 1.2-1.8.